### PR TITLE
Delete shard iterator to resolve memory leak

### DIFF
--- a/lib/readable.js
+++ b/lib/readable.js
@@ -138,6 +138,7 @@ class KinesisReadable extends Readable {
       // make sure we know that we are still watching a shard
       this.iterators.add(shardIterator)
       await sleep(this.options.interval)
+      this.iterators.delete(shardIterator);
       return this.readShard(nextShardIterator)
     }
   }


### PR DESCRIPTION
We have noticed a memory leak when using this library in our app. It seems to be resolved by deleting the shard iterator after it has been added the second time